### PR TITLE
feat: rename Tabletron component to MassiveTable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm i react-massive-table
 Minimal, client-side rows from an in-memory array:
 
 ```tsx
-import { Tabletron } from 'react-massive-table'
+import { MassiveTable } from 'react-massive-table'
 
 type Row = { id: number; name: string; value: number }
 const data: Row[] = Array.from({ length: 100_000 }, (_, i) => ({
@@ -46,7 +46,7 @@ function App() {
     total: data.length,
   })
   return (
-    <Tabletron<Row>
+    <MassiveTable<Row>
       getRows={getRows}
       rowCount={data.length}
       columns={columns}
@@ -67,7 +67,7 @@ function App() {
 
 ## API Reference
 
-### `Tabletron<Row>(props)`
+### `MassiveTable<Row>(props)`
 
 #### Required Props
 - `getRows(start, end, req)`: Returns either `Row[]` or `{ rows: Row[]; total: number }`. `req` contains current `sorts`, `groupBy`, and `{ expandedKeys }` for servers that flatten grouped results.
@@ -142,7 +142,7 @@ Built-ins: `mode='light' | 'dark'` set sensible defaults via CSS variables.
 
 **Example**:
 ```tsx
-<Tabletron
+<MassiveTable
   getRows={getRows}
   rowCount={rowCount}
   columns={columns}
@@ -179,4 +179,3 @@ A demo app (`src/App.tsx`) generates deterministic data, showcases grouping, and
 ## License
 
 MIT
-

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import Chance from 'chance';
 import * as React from 'react';
-import Tabletron from './lib/Tabletron';
+import MassiveTable from './lib/MassiveTable';
 import type { ColumnDef, ColumnPath, GetRowsResult, RowsRequest, Sort } from './lib/types';
 import { getByPath } from './lib/utils';
 
@@ -51,11 +51,11 @@ const columns: ColumnDef<Row | GroupHeader>[] = [
 
 export default function App() {
   const [mode, setMode] = React.useState<'light' | 'dark'>(
-    () => (localStorage.getItem('tabletron-mode') as 'light' | 'dark') || 'light',
+    () => (localStorage.getItem('massive-table-mode') as 'light' | 'dark') || 'light',
   );
   React.useEffect(() => {
     try {
-      localStorage.setItem('tabletron-mode', mode);
+      localStorage.setItem('massive-table-mode', mode);
     } catch {}
   }, [mode]);
   // Build demo data in-memory (deterministic via Chance + SEED)
@@ -188,7 +188,7 @@ export default function App() {
   // Storybook-like example registry
   type Variant = {
     name: string;
-    props: Partial<React.ComponentProps<typeof Tabletron<Row | GroupHeader>>>;
+    props: Partial<React.ComponentProps<typeof MassiveTable<Row | GroupHeader>>>;
     note?: string;
   };
   type Example = { key: string; title: string; variants: Variant[] };
@@ -326,7 +326,7 @@ export default function App() {
         }}
       >
         <div style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
-          <h1 style={{ margin: 0, fontSize: 18 }}>Tabletron Examples</h1>
+          <h1 style={{ margin: 0, fontSize: 18 }}>MassiveTable Examples</h1>
           {activeExample.key === 'reorder' && (
             <span style={{ color: '#555' }}>
               {previewOrder
@@ -454,7 +454,7 @@ export default function App() {
               {activeVariant.note ? ` — ${activeVariant.note}` : ''}
             </p>
           </div>
-          <Tabletron<Row | GroupHeader>
+          <MassiveTable<Row | GroupHeader>
             key={`${activeExample.key}:${activeVariantIndex}`}
             getRows={getRows}
             rowCount={rowCount}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/Tabletron';
+export * from './lib/MassiveTable';

--- a/src/lib/MassiveTable.tsx
+++ b/src/lib/MassiveTable.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import baseStyles from './styles/base.module.css';
 import darkTheme from './styles/dark.module.css';
 import lightTheme from './styles/light.module.css';
@@ -7,8 +8,8 @@ import type {
   GetRowsResult,
   GroupBy,
   GroupState,
+  MassiveTableProps,
   Sort,
-  TabletronProps,
   Theme,
 } from './types';
 import { clamp, getByPath, toPx } from './utils';
@@ -79,7 +80,7 @@ function useColumnOrder<Row>(columns: ColumnDef<Row>[]) {
   return { order, columnsOrdered: cols, move } as const;
 }
 
-export function Tabletron<Row = unknown>(props: TabletronProps<Row>) {
+export function MassiveTable<Row = unknown>(props: MassiveTableProps<Row>) {
   const {
     getRows,
     rowCount,
@@ -308,10 +309,10 @@ export function Tabletron<Row = unknown>(props: TabletronProps<Row>) {
     const t = { ...DEFAULT_THEME, ...(theme ?? {}) };
     // Always provide layout-related variables that depend on props
     const layoutVars: React.CSSProperties & Record<string, string> = {
-      '--tabletron-header-h': t.headerHeight ?? '36px',
-      '--tabletron-cell-py': t.cellPxY ?? '8px',
-      '--tabletron-header-cell-py': t.headerCellPy ?? t.cellPxY ?? '8px',
-      '--tabletron-cell-px': t.cellPxX ?? '12px',
+      '--massive-table-header-h': t.headerHeight ?? '36px',
+      '--massive-table-cell-py': t.cellPxY ?? '8px',
+      '--massive-table-header-cell-py': t.headerCellPy ?? t.cellPxY ?? '8px',
+      '--massive-table-cell-px': t.cellPxX ?? '12px',
     };
 
     // If a theme object is provided, opt into setting color/visual variables.
@@ -319,20 +320,20 @@ export function Tabletron<Row = unknown>(props: TabletronProps<Row>) {
     if (theme) {
       return {
         ...layoutVars,
-        '--tabletron-bg': t.bg,
-        '--tabletron-color': t.color,
-        '--tabletron-header-bg': t.headerBg,
-        '--tabletron-header-color': t.headerColor,
-        '--tabletron-row-hover-bg': t.rowHoverBg,
-        '--tabletron-row-hover-color': t.rowHoverColor ?? t.color,
-        '--tabletron-border': t.borderColor,
-        '--tabletron-scrollbar-thumb': t.scrollbarThumb,
-        '--tabletron-scrollbar-track': t.scrollbarTrack,
-        '--tabletron-radius': t.radius ?? '8px',
-        '--tabletron-header-shadow': t.headerShadow ?? 'inset 0 -1px 0 rgba(0,0,0,0.06)',
-        '--tabletron-row-stripe': t.rowStripeBg ?? 'transparent',
-        '--tabletron-focus-ring': t.focusRing ?? '0 0 0 2px rgba(59,130,246,0.65)',
-        '--tabletron-dim-overlay': t.dimOverlay ?? 'rgba(0,0,0,0.1)',
+        '--massive-table-bg': t.bg,
+        '--massive-table-color': t.color,
+        '--massive-table-header-bg': t.headerBg,
+        '--massive-table-header-color': t.headerColor,
+        '--massive-table-row-hover-bg': t.rowHoverBg,
+        '--massive-table-row-hover-color': t.rowHoverColor ?? t.color,
+        '--massive-table-border': t.borderColor,
+        '--massive-table-scrollbar-thumb': t.scrollbarThumb,
+        '--massive-table-scrollbar-track': t.scrollbarTrack,
+        '--massive-table-radius': t.radius ?? '8px',
+        '--massive-table-header-shadow': t.headerShadow ?? 'inset 0 -1px 0 rgba(0,0,0,0.06)',
+        '--massive-table-row-stripe': t.rowStripeBg ?? 'transparent',
+        '--massive-table-focus-ring': t.focusRing ?? '0 0 0 2px rgba(59,130,246,0.65)',
+        '--massive-table-dim-overlay': t.dimOverlay ?? 'rgba(0,0,0,0.1)',
       } as React.CSSProperties & Record<string, string>;
     }
 
@@ -352,11 +353,11 @@ export function Tabletron<Row = unknown>(props: TabletronProps<Row>) {
     e.dataTransfer.effectAllowed = 'move';
     e.dataTransfer.setData('text/plain', String(idx));
     try {
-      e.dataTransfer.setData('application/x-tabletron-col-idx', String(idx));
+      e.dataTransfer.setData('application/x-massive-table-col-idx', String(idx));
     } catch {}
     try {
       e.dataTransfer.setData(
-        'application/x-tabletron-col-path',
+        'application/x-massive-table-col-path',
         JSON.stringify(columnsOrdered[idx].path),
       );
     } catch {}
@@ -551,8 +552,8 @@ export function Tabletron<Row = unknown>(props: TabletronProps<Row>) {
   const [groupOver, setGroupOver] = React.useState<boolean>(false);
   const onGroupBarDragOver = (e: React.DragEvent) => {
     if (
-      e.dataTransfer.types.includes('application/x-tabletron-col-idx') ||
-      e.dataTransfer.types.includes('application/x-tabletron-group-idx') ||
+      e.dataTransfer.types.includes('application/x-massive-table-col-idx') ||
+      e.dataTransfer.types.includes('application/x-massive-table-group-idx') ||
       e.dataTransfer.types.includes('text/plain')
     ) {
       e.preventDefault();
@@ -574,11 +575,11 @@ export function Tabletron<Row = unknown>(props: TabletronProps<Row>) {
     setGroupOver(false);
     // Mark that a drop occurred within the group bar region
     groupDropInsideRef.current = true;
-    const colPathStr = e.dataTransfer.getData('application/x-tabletron-col-path');
+    const colPathStr = e.dataTransfer.getData('application/x-massive-table-col-path');
     const colIdxStr =
-      e.dataTransfer.getData('application/x-tabletron-col-idx') ||
+      e.dataTransfer.getData('application/x-massive-table-col-idx') ||
       e.dataTransfer.getData('text/plain');
-    const fromGroupStr = e.dataTransfer.getData('application/x-tabletron-group-idx');
+    const fromGroupStr = e.dataTransfer.getData('application/x-massive-table-group-idx');
     if (fromGroupStr) return; // reordering handled continuously during drag
     if (colPathStr) {
       try {
@@ -618,7 +619,7 @@ export function Tabletron<Row = unknown>(props: TabletronProps<Row>) {
   const onGroupChipDragStart = (i: number) => (e: React.DragEvent) => {
     groupDragIndex.current = i;
     e.dataTransfer.effectAllowed = 'move';
-    e.dataTransfer.setData('application/x-tabletron-group-idx', String(i));
+    e.dataTransfer.setData('application/x-massive-table-group-idx', String(i));
     // Drag originates inside the group bar; consider pointer over the bar
     setGroupOver(true);
     // Reset drop flag for this drag sequence
@@ -637,14 +638,14 @@ export function Tabletron<Row = unknown>(props: TabletronProps<Row>) {
     if (el) {
       const over = (ev: DragEvent) => {
         const types = Array.from(ev.dataTransfer?.types ?? []);
-        if (types.includes('application/x-tabletron-group-idx')) {
+        if (types.includes('application/x-massive-table-group-idx')) {
           ev.preventDefault();
           if (ev.dataTransfer) ev.dataTransfer.dropEffect = 'move';
         }
       };
       const drop = (ev: DragEvent) => {
         const types = Array.from(ev.dataTransfer?.types ?? []);
-        if (types.includes('application/x-tabletron-group-idx')) {
+        if (types.includes('application/x-massive-table-group-idx')) {
           ev.preventDefault();
         }
       };
@@ -731,9 +732,9 @@ export function Tabletron<Row = unknown>(props: TabletronProps<Row>) {
         // Fallback to header height var until measured
         ...(showGroupByDropZone
           ? groupBarHeight != null
-            ? { ['--tabletron-groupbar-h' as string]: `${groupBarHeight}px` }
+            ? { ['--massive-table-groupbar-h' as string]: `${groupBarHeight}px` }
             : {}
-          : { ['--tabletron-groupbar-h' as string]: '0px' }),
+          : { ['--massive-table-groupbar-h' as string]: '0px' }),
         ...style,
       }}
     >
@@ -877,7 +878,7 @@ export function Tabletron<Row = unknown>(props: TabletronProps<Row>) {
                         <div
                           className={baseStyles.groupRow}
                           style={{
-                            paddingLeft: `calc(var(--tabletron-cell-px) + ${(r.depth ?? 0) * 16}px)`,
+                            paddingLeft: `calc(var(--massive-table-cell-px) + ${(r.depth ?? 0) * 16}px)`,
                           }}
                         >
                           <button
@@ -936,4 +937,4 @@ export function Tabletron<Row = unknown>(props: TabletronProps<Row>) {
   );
 }
 
-export default Tabletron;
+export default MassiveTable;

--- a/src/lib/styles/base.module.css
+++ b/src/lib/styles/base.module.css
@@ -1,15 +1,15 @@
 /* Base structural styles and tokens using CSS variables */
 .root {
-  --tabletron-radius: var(--tabletron-radius, 10px);
-  --tabletron-header-h: var(--tabletron-header-h, 36px);
-  --tabletron-cell-px: var(--tabletron-cell-px, 10px);
-  --tabletron-cell-py: var(--tabletron-cell-py, 6px);
-  --tabletron-header-cell-py: var(--tabletron-header-cell-py, 4px);
+  --massive-table-radius: var(--massive-table-radius, 10px);
+  --massive-table-header-h: var(--massive-table-header-h, 36px);
+  --massive-table-cell-px: var(--massive-table-cell-px, 10px);
+  --massive-table-cell-py: var(--massive-table-cell-py, 6px);
+  --massive-table-header-cell-py: var(--massive-table-header-cell-py, 4px);
 
-  background: var(--tabletron-bg);
-  color: var(--tabletron-color);
-  border: 1px solid var(--tabletron-border);
-  border-radius: var(--tabletron-radius);
+  background: var(--massive-table-bg);
+  color: var(--massive-table-color);
+  border: 1px solid var(--massive-table-border);
+  border-radius: var(--massive-table-radius);
   height: 100%;
   display: flex;
   flex-direction: column;
@@ -35,7 +35,7 @@
   overflow: auto;
   height: 100%;
   contain: content;
-  background: var(--tabletron-bg);
+  background: var(--massive-table-bg);
 }
 
 /* Scrollbar polish */
@@ -44,11 +44,11 @@
   width: 10px;
 }
 .viewport::-webkit-scrollbar-thumb {
-  background: var(--tabletron-scrollbar-thumb);
+  background: var(--massive-table-scrollbar-thumb);
   border-radius: 999px;
 }
 .viewport::-webkit-scrollbar-track {
-  background: var(--tabletron-scrollbar-track);
+  background: var(--massive-table-scrollbar-track);
 }
 
 /* Group bar */
@@ -59,15 +59,15 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  min-height: calc(var(--tabletron-header-h));
-  padding: var(--tabletron-header-cell-py) var(--tabletron-cell-px);
-  background: var(--tabletron-header-bg);
-  color: var(--tabletron-header-color);
-  border-bottom: 1px solid var(--tabletron-border);
-  box-shadow: var(--tabletron-header-shadow);
+  min-height: calc(var(--massive-table-header-h));
+  padding: var(--massive-table-header-cell-py) var(--massive-table-cell-px);
+  background: var(--massive-table-header-bg);
+  color: var(--massive-table-header-color);
+  border-bottom: 1px solid var(--massive-table-border);
+  box-shadow: var(--massive-table-header-shadow);
 }
 .groupBarOver {
-  outline: 2px dashed var(--tabletron-border);
+  outline: 2px dashed var(--massive-table-border);
   outline-offset: -4px;
 }
 .groupLabel {
@@ -80,7 +80,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  border: 1px solid var(--tabletron-border);
+  border: 1px solid var(--massive-table-border);
   background: transparent;
   color: inherit;
   border-radius: 999px;
@@ -106,27 +106,27 @@
 /* Header */
 .header {
   position: sticky;
-  top: var(--tabletron-groupbar-h, var(--tabletron-header-h));
+  top: var(--massive-table-groupbar-h, var(--massive-table-header-h));
   z-index: 2;
   display: grid;
   align-items: center;
-  background: var(--tabletron-header-bg);
-  color: var(--tabletron-header-color);
-  min-height: var(--tabletron-header-h);
-  border-bottom: 1px solid var(--tabletron-border);
-  box-shadow: var(--tabletron-header-shadow);
+  background: var(--massive-table-header-bg);
+  color: var(--massive-table-header-color);
+  min-height: var(--massive-table-header-h);
+  border-bottom: 1px solid var(--massive-table-border);
+  box-shadow: var(--massive-table-header-shadow);
 }
 
 .headerCell {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: var(--tabletron-header-cell-py) var(--tabletron-cell-px);
+  padding: var(--massive-table-header-cell-py) var(--massive-table-cell-px);
   border: 0;
   background: transparent;
   color: inherit;
   text-align: left;
-  border-right: 1px solid var(--tabletron-border);
+  border-right: 1px solid var(--massive-table-border);
   white-space: nowrap;
   user-select: none;
   position: relative;
@@ -142,7 +142,7 @@
 }
 .headerCell:focus-visible {
   outline: none;
-  box-shadow: var(--tabletron-focus-ring);
+  box-shadow: var(--massive-table-focus-ring);
 }
 .headerTitle {
   flex: 1 1 auto;
@@ -183,7 +183,7 @@
   left: 50%;
   transform: translateX(-50%);
   width: 1px;
-  background: var(--tabletron-border);
+  background: var(--massive-table-border);
 }
 
 /* Rows */
@@ -197,32 +197,32 @@
   right: 0;
   display: grid;
   align-items: center;
-  background: var(--tabletron-bg);
-  color: var(--tabletron-color);
+  background: var(--massive-table-bg);
+  color: var(--massive-table-color);
   border: 0;
-  border-bottom: 1px solid var(--tabletron-border);
-  padding: var(--tabletron-cell-py) 0;
+  border-bottom: 1px solid var(--massive-table-border);
+  padding: var(--massive-table-cell-py) 0;
   text-align: left;
 }
 .row:nth-child(even) {
-  background: var(--tabletron-row-stripe);
+  background: var(--massive-table-row-stripe);
 }
 .row:hover {
-  background: var(--tabletron-row-hover-bg);
-  color: var(--tabletron-row-hover-color);
+  background: var(--massive-table-row-hover-bg);
+  color: var(--massive-table-row-hover-color);
 }
 .row:focus-visible {
   outline: none;
-  box-shadow: var(--tabletron-focus-ring);
+  box-shadow: var(--massive-table-focus-ring);
 }
 
 /* Allow theme to enforce a measurement height via CSS */
 .rows > .row {
-  min-height: var(--tabletron-first-row-min-h, auto);
+  min-height: var(--massive-table-first-row-min-h, auto);
 }
 
 .cell {
-  padding: 0 var(--tabletron-cell-px);
+  padding: 0 var(--massive-table-cell-px);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -233,11 +233,11 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 var(--tabletron-cell-px);
+  padding: 0 var(--massive-table-cell-px);
   font-weight: 600;
 }
 .groupToggle {
-  border: 1px solid var(--tabletron-border);
+  border: 1px solid var(--massive-table-border);
   background: transparent;
   color: inherit;
   border-radius: 6px;

--- a/src/lib/styles/dark.module.css
+++ b/src/lib/styles/dark.module.css
@@ -1,17 +1,17 @@
 .theme {
-  --tabletron-bg: #0b1220;
-  --tabletron-color: #e5e7eb;
-  --tabletron-header-bg: #0f172a;
-  --tabletron-header-color: #e5e7eb;
-  --tabletron-row-hover-bg: #111827;
-  --tabletron-row-hover-color: #f3f4f6;
-  --tabletron-border: #1f2937;
-  --tabletron-scrollbar-thumb: #374151;
-  --tabletron-scrollbar-track: transparent;
-  --tabletron-radius: 10px;
-  --tabletron-header-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.05);
-  --tabletron-row-stripe: #0d1526;
-  --tabletron-focus-ring: 0 0 0 2px rgba(96, 165, 250, 0.55);
+  --massive-table-bg: #0b1220;
+  --massive-table-color: #e5e7eb;
+  --massive-table-header-bg: #0f172a;
+  --massive-table-header-color: #e5e7eb;
+  --massive-table-row-hover-bg: #111827;
+  --massive-table-row-hover-color: #f3f4f6;
+  --massive-table-border: #1f2937;
+  --massive-table-scrollbar-thumb: #374151;
+  --massive-table-scrollbar-track: transparent;
+  --massive-table-radius: 10px;
+  --massive-table-header-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.05);
+  --massive-table-row-stripe: #0d1526;
+  --massive-table-focus-ring: 0 0 0 2px rgba(96, 165, 250, 0.55);
   /* Optional: theme can set the first row min height for measurement */
-  --tabletron-first-row-min-h: 32px;
+  --massive-table-first-row-min-h: 32px;
 }

--- a/src/lib/styles/light.module.css
+++ b/src/lib/styles/light.module.css
@@ -1,17 +1,17 @@
 .theme {
-  --tabletron-bg: #ffffff;
-  --tabletron-color: #0f172a;
-  --tabletron-header-bg: #f8fafc;
-  --tabletron-header-color: #0f172a;
-  --tabletron-row-hover-bg: #f1f5f9;
-  --tabletron-row-hover-color: #0f172a;
-  --tabletron-border: #e2e8f0;
-  --tabletron-scrollbar-thumb: #cbd5e1;
-  --tabletron-scrollbar-track: transparent;
-  --tabletron-radius: 10px;
-  --tabletron-header-shadow: inset 0 -1px 0 rgba(15, 23, 42, 0.08);
-  --tabletron-row-stripe: #fafbfc;
-  --tabletron-focus-ring: 0 0 0 2px rgba(59, 130, 246, 0.6);
+  --massive-table-bg: #ffffff;
+  --massive-table-color: #0f172a;
+  --massive-table-header-bg: #f8fafc;
+  --massive-table-header-color: #0f172a;
+  --massive-table-row-hover-bg: #f1f5f9;
+  --massive-table-row-hover-color: #0f172a;
+  --massive-table-border: #e2e8f0;
+  --massive-table-scrollbar-thumb: #cbd5e1;
+  --massive-table-scrollbar-track: transparent;
+  --massive-table-radius: 10px;
+  --massive-table-header-shadow: inset 0 -1px 0 rgba(15, 23, 42, 0.08);
+  --massive-table-row-stripe: #fafbfc;
+  --massive-table-focus-ring: 0 0 0 2px rgba(59, 130, 246, 0.6);
   /* Optional: theme can set the first row min height for measurement */
-  --tabletron-first-row-min-h: 32px;
+  --massive-table-first-row-min-h: 32px;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,7 +66,7 @@ export type GetRows<Row = unknown> = (
   req?: RowsRequest<Row>,
 ) => Promise<GetRowsResult<Row> | Row[]> | GetRowsResult<Row> | Row[];
 
-export type TabletronEvents<Row = unknown> = {
+export type MassiveTableEvents<Row = unknown> = {
   onVisibleRangeChange?: (start: number, end: number) => void;
   onRowsRendered?: (start: number, end: number) => void;
   // Fires while dragging columns as the order changes live
@@ -80,14 +80,14 @@ export type TabletronEvents<Row = unknown> = {
   onExpandedKeysChange?: (expandedKeys: string[]) => void;
 };
 
-export type TabletronProps<Row = unknown> = TabletronEvents<Row> & {
+export type MassiveTableProps<Row = unknown> = MassiveTableEvents<Row> & {
   getRows: GetRows<Row>;
   rowCount: number;
   columns: ColumnDef<Row>[];
   rowHeight?: number | string | 'auto'; // e.g. 48, '75px', or 'auto'
   overscan?: number; // number of extra rows above/below
   theme?: Partial<Theme>;
-  // Preferred built-in theme mode. Applies Tabletron's CSS-module theme tokens.
+  // Preferred built-in theme mode. Applies MassiveTable's CSS-module theme tokens.
   mode?: 'light' | 'dark';
   style?: React.CSSProperties;
   className?: string;

--- a/tests/massive-table.basic.test.tsx
+++ b/tests/massive-table.basic.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { act } from 'react';
 import * as React from 'react';
-import { Tabletron } from '../src';
+import { MassiveTable } from '../src';
 import type { ColumnDef, GetRowsResult, RowsRequest } from '../src/lib/types';
 
 type Row = { a: number; b: string };
@@ -28,12 +28,12 @@ function makeGetRows(rows = makeData()) {
     }));
 }
 
-describe('Tabletron basic', () => {
+describe('MassiveTable basic', () => {
   it('calls getRows with overscan and renders rows', async () => {
     const getRows = makeGetRows();
     await act(async () => {
       render(
-        <Tabletron<Row>
+        <MassiveTable<Row>
           getRows={getRows}
           rowCount={50}
           columns={columns}
@@ -60,7 +60,7 @@ describe('Tabletron basic', () => {
     const getRows = makeGetRows();
     const onSortsChange = vi.fn();
     render(
-      <Tabletron<Row>
+      <MassiveTable<Row>
         getRows={getRows}
         rowCount={50}
         columns={columns}
@@ -86,7 +86,7 @@ describe('Tabletron basic', () => {
     const getRows = makeGetRows(makeData(20));
     const onRowClick = vi.fn();
     render(
-      <Tabletron<Row>
+      <MassiveTable<Row>
         getRows={getRows}
         rowCount={20}
         columns={columns}

--- a/tests/massive-table.grouping.test.tsx
+++ b/tests/massive-table.grouping.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { act } from 'react';
 import * as React from 'react';
-import { Tabletron } from '../src';
+import { MassiveTable } from '../src';
 import type { ColumnDef, GetRowsResult, RowsRequest } from '../src/lib/types';
 
 type Row = { a: number; b: string };
@@ -41,11 +41,11 @@ class MockDataTransfer {
   setDragImage() {}
 }
 
-describe('Tabletron grouping', () => {
+describe('MassiveTable grouping', () => {
   it('adds a group via header -> group bar drop', async () => {
     const getRows = makeGetRowsGrouped();
     render(
-      <Tabletron<Row>
+      <MassiveTable<Row>
         getRows={getRows}
         rowCount={2}
         columns={columns}
@@ -57,7 +57,7 @@ describe('Tabletron grouping', () => {
     const groupBar = screen.getByRole('toolbar', { name: /Group by bar/i });
     const dt = new MockDataTransfer();
     // Include the column path payload
-    dt.setData('application/x-tabletron-col-path', JSON.stringify(['a']));
+    dt.setData('application/x-massive-table-col-path', JSON.stringify(['a']));
     await act(async () => {
       fireEvent.dragStart(headerA, { dataTransfer: dt });
       fireEvent.dragOver(groupBar, { dataTransfer: dt });
@@ -70,7 +70,7 @@ describe('Tabletron grouping', () => {
   it('removes a group when chip drag ends outside', async () => {
     const getRows = makeGetRowsGrouped();
     const { container } = render(
-      <Tabletron<Row>
+      <MassiveTable<Row>
         getRows={getRows}
         rowCount={2}
         columns={columns}
@@ -92,7 +92,7 @@ describe('Tabletron grouping', () => {
   it('toggles group row expand/collapse', async () => {
     const getRows = makeGetRowsGrouped();
     render(
-      <Tabletron<Row>
+      <MassiveTable<Row>
         getRows={getRows}
         rowCount={2}
         columns={columns}

--- a/tests/massive-table.reorder-resize.test.tsx
+++ b/tests/massive-table.reorder-resize.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { act } from 'react';
 import * as React from 'react';
-import { Tabletron } from '../src';
+import { MassiveTable } from '../src';
 import type { ColumnDef, GetRowsResult, RowsRequest } from '../src/lib/types';
 
 type Row = { a: number; b: string };
@@ -37,13 +37,13 @@ class MockDataTransfer {
   setDragImage() {}
 }
 
-describe('Tabletron reorder & resize', () => {
+describe('MassiveTable reorder & resize', () => {
   it('reorders columns via drag and notifies preview/final', async () => {
     const getRows = makeGetRows();
     const onPreview = vi.fn();
     const onFinal = vi.fn();
     render(
-      <Tabletron<Row>
+      <MassiveTable<Row>
         getRows={getRows}
         rowCount={10}
         columns={columns}
@@ -76,7 +76,7 @@ describe('Tabletron reorder & resize', () => {
   it('resizes a column via grip drag', async () => {
     const getRows = makeGetRows();
     const { container } = render(
-      <Tabletron<Row>
+      <MassiveTable<Row>
         getRows={getRows}
         rowCount={10}
         columns={columns}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   build: {
     lib: {
       entry: 'src/index.ts',
-      name: 'Tabletron',
+      name: 'MassiveTable',
       fileName: (format) => (format === 'cjs' ? 'index.cjs' : 'index.js'),
     },
     rollupOptions: {


### PR DESCRIPTION
## Summary
- Renames the main component from `Tabletron` to `MassiveTable` throughout the codebase
- Updates all references including documentation, tests, CSS variables, and local storage keys
- Provides a more descriptive name that better reflects the component's purpose

## Changes
- Component files: `Tabletron.tsx` → `MassiveTable.tsx`
- Export statements and imports updated across all files
- Test files renamed and updated
- README documentation updated with new component name
- CSS variable names updated from `--tabletron-*` to `--massive-table-*`
- Local storage keys updated to use new component name

## Test plan
- [ ] Verify all existing tests pass with the new component name
- [ ] Confirm the demo application works correctly
- [ ] Check that the component exports properly from the main index
- [ ] Validate CSS styling still applies correctly with new variable names