### PR TITLE
feat: improve inline group functionality with dedicated toggle column

### DIFF
--- a/src/lib/MassiveTable.tsx
+++ b/src/lib/MassiveTable.tsx
@@ -178,6 +178,7 @@ export function MassiveTable<Row = unknown>(props: MassiveTableProps<Row>) {
     `${sortsSig}|${groupSig}`,
   );
   const { columnsOrdered, order, move } = useColumnOrder(columns);
+  const hasInlineGroup = React.useMemo(() => columns.some((c) => !!c.inlineGroup), [columns]);
 
   // To avoid browser max scroll height limits (~16.7M px in some engines),
   // we chunk the scrollable canvas and keep a base offset we subtract from
@@ -302,8 +303,15 @@ export function MassiveTable<Row = unknown>(props: MassiveTableProps<Row>) {
   }, [effectiveRowCount, rowH]);
 
   // Build grid columns template based on widths
-  const gridTemplate = React.useMemo(() => colWidths.map((w) => `${w}px`).join(' '), [colWidths]);
-  const totalWidth = React.useMemo(() => colWidths.reduce((a, b) => a + b, 0), [colWidths]);
+  const inlineColWidth = 28; // px for dedicated inline-group toggle column when present
+  const gridTemplate = React.useMemo(() => {
+    const widths = hasInlineGroup ? [inlineColWidth, ...colWidths] : colWidths;
+    return widths.map((w) => `${w}px`).join(' ');
+  }, [colWidths, hasInlineGroup]);
+  const totalWidth = React.useMemo(() => {
+    const base = colWidths.reduce((a, b) => a + b, 0);
+    return hasInlineGroup ? base + inlineColWidth : base;
+  }, [colWidths, hasInlineGroup]);
 
   const themeVars = React.useMemo(() => {
     const t = { ...DEFAULT_THEME, ...(theme ?? {}) };
@@ -781,6 +789,9 @@ export function MassiveTable<Row = unknown>(props: MassiveTableProps<Row>) {
           className={baseStyles.header}
           style={{ gridTemplateColumns: gridTemplate, width: totalWidth }}
         >
+          {hasInlineGroup && (
+            <div key="__inline-toggle" className={baseStyles.headerCell} aria-hidden />
+          )}
           {columnsOrdered.map((col, i) => {
             const sortIdx = sorts.findIndex((s) => pathEq(s.path, col.path));
             const sortDir = sortIdx >= 0 ? sorts[sortIdx].dir : null;
@@ -919,7 +930,101 @@ export function MassiveTable<Row = unknown>(props: MassiveTableProps<Row>) {
                         </div>
                       );
                     }
-                    return columnsOrdered.map((col, ci) => {
+                    // Optional leading inline-group toggle column
+                    const meta = (row ?? ({} as unknown)) as {
+                      __inlineGroupKey?: string;
+                      __inlineGroupAnchor?: boolean;
+                      __inlineGroupMember?: boolean;
+                      __inlineGroupExpanded?: boolean;
+                    };
+
+                    const inlineCell = hasInlineGroup ? (
+                      <div
+                        key={`${rowIndex}:-1`}
+                        className={baseStyles.cell}
+                        style={{
+                          padding: 0,
+                          margin: 'calc(var(--massive-table-cell-py) * -1) 0',
+                          height: 'calc(100% + var(--massive-table-cell-py) * 2)',
+                        }}
+                      >
+                        {row == null ? (
+                          <span
+                            style={{
+                              opacity: 0.4,
+                              padding: '0 var(--massive-table-cell-px)',
+                              display: 'flex',
+                              alignItems: 'center',
+                              height: '100%',
+                            }}
+                          >
+                            …
+                          </span>
+                        ) : (
+                          (() => {
+                            const key = meta.__inlineGroupKey;
+                            const isAnchor = !!meta.__inlineGroupAnchor;
+                            const isMember = !!meta.__inlineGroupMember;
+                            const expanded = key
+                              ? expandedSet.has(key)
+                              : !!meta.__inlineGroupExpanded;
+                            const arrow = isAnchor ? (expanded ? '▾' : '▸') : isMember ? '·' : '';
+                            const onToggle = (e: React.MouseEvent) => {
+                              e.stopPropagation();
+                              if (!key) return;
+                              toggleGroupKey(key);
+                            };
+                            return (
+                              <>
+                                {isAnchor ? (
+                                  <button
+                                    onClick={onToggle}
+                                    aria-label={
+                                      expanded ? 'Collapse inline group' : 'Expand inline group'
+                                    }
+                                    type="button"
+                                    style={{
+                                      width: '18px',
+                                      height: '100%',
+                                      border: 'none',
+                                      background: 'var(--massive-table-inline-group-bg)',
+                                      color: 'inherit',
+                                      cursor: 'pointer',
+                                      display: 'flex',
+                                      alignItems: 'center',
+                                      justifyContent: 'center',
+                                      fontSize: 12,
+                                      margin: 0,
+                                      padding: 0,
+                                    }}
+                                  >
+                                    {arrow}
+                                  </button>
+                                ) : (
+                                  <div
+                                    style={{
+                                      width: '18px',
+                                      height: '100%',
+                                      background: isMember
+                                        ? 'var(--massive-table-inline-group-bg)'
+                                        : 'transparent',
+                                      display: 'flex',
+                                      alignItems: 'center',
+                                      justifyContent: 'center',
+                                      fontSize: 12,
+                                    }}
+                                  >
+                                    {arrow}
+                                  </div>
+                                )}
+                              </>
+                            );
+                          })()
+                        )}
+                      </div>
+                    ) : null;
+
+                    const dataCells = columnsOrdered.map((col, ci) => {
                       const value = row == null ? undefined : getByPath(row, col.path);
                       const content = col.render ? (
                         col.render(value, row as Row, rowIndex)
@@ -940,6 +1045,8 @@ export function MassiveTable<Row = unknown>(props: MassiveTableProps<Row>) {
                         </div>
                       );
                     });
+
+                    return [inlineCell, ...dataCells].filter(Boolean);
                   })()}
                 </div>
               </React.Fragment>

--- a/src/lib/MassiveTable.tsx
+++ b/src/lib/MassiveTable.tsx
@@ -979,9 +979,7 @@ export function MassiveTable<Row = unknown>(props: MassiveTableProps<Row>) {
                                 {isAnchor ? (
                                   <button
                                     onClick={onToggle}
-                                    aria-label={
-                                      expanded ? 'Collapse inline group' : 'Expand inline group'
-                                    }
+                                    aria-label={expanded ? 'Collapse trace' : 'Expand trace'}
                                     type="button"
                                     style={{
                                       width: '18px',

--- a/src/lib/styles/base.module.css
+++ b/src/lib/styles/base.module.css
@@ -204,9 +204,6 @@
   padding: var(--massive-table-cell-py) 0;
   text-align: left;
 }
-.row:nth-child(even) {
-  background: var(--massive-table-row-stripe);
-}
 .row:hover {
   background: var(--massive-table-row-hover-bg);
   color: var(--massive-table-row-hover-color);

--- a/src/lib/styles/dark.module.css
+++ b/src/lib/styles/dark.module.css
@@ -12,6 +12,7 @@
   --massive-table-header-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.05);
   --massive-table-row-stripe: #0d1526;
   --massive-table-focus-ring: 0 0 0 2px rgba(96, 165, 250, 0.55);
+  --massive-table-inline-group-bg: rgba(96, 165, 250, 0.12);
   /* Optional: theme can set the first row min height for measurement */
   --massive-table-first-row-min-h: 32px;
 }

--- a/src/lib/styles/light.module.css
+++ b/src/lib/styles/light.module.css
@@ -12,6 +12,7 @@
   --massive-table-header-shadow: inset 0 -1px 0 rgba(15, 23, 42, 0.08);
   --massive-table-row-stripe: #fafbfc;
   --massive-table-focus-ring: 0 0 0 2px rgba(59, 130, 246, 0.6);
+  --massive-table-inline-group-bg: rgba(59, 130, 246, 0.08);
   /* Optional: theme can set the first row min height for measurement */
   --massive-table-first-row-min-h: 32px;
 }


### PR DESCRIPTION
## Summary

- Refactors inline group functionality to use a dedicated toggle column instead of mixing with data columns
- Improves visual clarity and user experience for grouped data
- Adds proper expansion state management and visual indicators
- Cleans up demo code and adds custom render examples

## Key Changes

### Core Functionality
- **Dedicated toggle column**: Inline groups now use a separate column for expand/collapse controls
- **Better state management**: Improved handling of group expansion state with proper metadata support
- **Visual indicators**: Clear visual cues for group anchors (▸/▾) and members (·)

### Styling Improvements  
- **New CSS variables**: Added `--massive-table-inline-group-bg` for consistent theming
- **Removed row striping**: Better visual clarity when using inline groups
- **Responsive design**: Toggle column adapts properly to table layout

### Demo Enhancements
- **Simplified examples**: Removed complex syntax highlighting code to focus on core functionality  
- **Custom render showcase**: Added red pill example demonstrating column render overrides
- **Cleaner organization**: Better structured demo variants for easier understanding

## Test Plan

- [x] Verify inline group expansion/collapse works correctly
- [x] Check visual indicators display properly for anchors and members
- [x] Confirm custom render examples work as expected
- [x] Test responsive behavior of toggle column
- [x] Validate theming works in both light and dark modes

This enhancement improves the usability and maintainability of inline group functionality while providing better visual feedback to users.