### PR TITLE
feat: refactor to CSS modules build system with consumer-provided theming

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
-    "./styles.css": "./dist/style.css"
+    "./styles.css": "./dist/react-massive-table.css",
+    "./styles/base.module.css": "./dist/styles/base.module.css",
+    "./themes/light.module.css": "./dist/themes/light.module.css",
+    "./themes/dark.module.css": "./dist/themes/dark.module.css"
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc -p tsconfig.build.json && vite build",
+    "build": "tsc -p tsconfig.build.json && vite build && node scripts/copy-css.mjs",
     "preview": "vite preview",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "biome lint .",

--- a/scripts/copy-css.mjs
+++ b/scripts/copy-css.mjs
@@ -1,0 +1,31 @@
+import { mkdirSync, copyFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const root = resolve(process.cwd());
+const srcDir = resolve(root, 'src/lib/styles');
+const distStylesDir = resolve(root, 'dist/styles');
+const distThemesDir = resolve(root, 'dist/themes');
+const distStylesCss = resolve(root, 'dist/react-massive-table.css');
+
+function ensureDir(p) {
+  try {
+    mkdirSync(p, { recursive: true });
+  } catch {}
+}
+
+function copy(from, to) {
+  ensureDir(dirname(to));
+  copyFileSync(from, to);
+  console.log(`copied ${from.replace(root+'/', '')} -> ${to.replace(root+'/', '')}`);
+}
+
+ensureDir(distStylesDir);
+ensureDir(distThemesDir);
+
+copy(resolve(srcDir, 'base.module.css'), resolve(distStylesDir, 'base.module.css'));
+copy(resolve(srcDir, 'light.module.css'), resolve(distThemesDir, 'light.module.css'));
+copy(resolve(srcDir, 'dark.module.css'), resolve(distThemesDir, 'dark.module.css'));
+
+// Keep legacy export for side-effect CSS import path present (empty by design)
+writeFileSync(distStylesCss, '/* react-massive-table: no automatic CSS; import CSS modules instead */\n');
+console.log(`wrote dist/react-massive-table.css (stub)`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,9 @@ import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-tsx';
 import MassiveTable from './lib/MassiveTable';
+import baseClasses from './lib/styles/base.module.css';
+import darkTheme from './lib/styles/dark.module.css';
+import lightTheme from './lib/styles/light.module.css';
 import type { ColumnDef, ColumnPath, GetRowsResult, RowsRequest, Sort } from './lib/types';
 import { getByPath } from './lib/utils';
 
@@ -804,7 +807,8 @@ export default function App() {
             getRows={getRows}
             rowCount={rowCount}
             columns={columns}
-            mode={mode}
+            classes={baseClasses}
+            className={mode === 'dark' ? darkTheme.theme : lightTheme.theme}
             {...activeVariant.props}
             onColumnOrderPreviewChange={(o) => setPreviewOrder(o)}
             onColumnOrderChange={(o) => {

--- a/src/lib/styles/base.module.css
+++ b/src/lib/styles/base.module.css
@@ -1,10 +1,11 @@
 /* Base structural styles and tokens using CSS variables */
 .root {
-  --massive-table-radius: var(--massive-table-radius, 10px);
-  --massive-table-header-h: var(--massive-table-header-h, 36px);
-  --massive-table-cell-px: var(--massive-table-cell-px, 10px);
-  --massive-table-cell-py: var(--massive-table-cell-py, 6px);
-  --massive-table-header-cell-py: var(--massive-table-header-cell-py, 4px);
+  /* Base layout defaults; themes may override as needed */
+  --massive-table-radius: 10px;
+  --massive-table-header-h: 36px;
+  --massive-table-cell-px: 10px;
+  --massive-table-cell-py: 6px;
+  --massive-table-header-cell-py: 4px;
 
   background: var(--massive-table-bg);
   color: var(--massive-table-color);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,28 +14,6 @@ export type ColumnDef<Row = unknown> = {
   inlineGroup?: boolean;
 };
 
-export type Theme = {
-  bg: string;
-  color: string;
-  headerBg: string;
-  headerColor: string;
-  rowHoverBg: string;
-  rowHoverColor?: string;
-  borderColor: string;
-  scrollbarThumb: string;
-  scrollbarTrack: string;
-  // New theme tokens for polish (optional in props)
-  radius?: string; // e.g. '8px'
-  headerHeight?: string; // e.g. '48px'
-  cellPxY?: string; // e.g. '8px' vertical padding
-  cellPxX?: string; // e.g. '12px' horizontal padding
-  headerShadow?: string; // e.g. '0 1px 0 rgba(0,0,0,0.04)'
-  rowStripeBg?: string; // zebra strip background
-  focusRing?: string; // e.g. '0 0 0 2px #3b82f6'
-  dimOverlay?: string; // e.g. 'rgba(0,0,0,0.1)' darken non-active columns on drag
-  headerCellPy?: string; // header cell vertical padding (e.g. '4px')
-};
-
 export type SortDirection = 'asc' | 'desc';
 
 export type Sort<_Row = unknown> = {
@@ -90,9 +68,6 @@ export type MassiveTableProps<Row = unknown> = MassiveTableEvents<Row> & {
   columns: ColumnDef<Row>[];
   rowHeight?: number | string | 'auto'; // e.g. 48, '75px', or 'auto'
   overscan?: number; // number of extra rows above/below
-  theme?: Partial<Theme>;
-  // Preferred built-in theme mode. Applies MassiveTable's CSS-module theme tokens.
-  mode?: 'light' | 'dark';
   style?: React.CSSProperties;
   className?: string;
   // Optional CSS Modules override for theming

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,17 +11,12 @@ export default defineConfig({
   build: {
     lib: {
       entry: 'src/index.ts',
-      name: 'MassiveTable',
-      fileName: (format) => (format === 'cjs' ? 'index.cjs' : 'index.js'),
+      // Only emit ESM and CJS for library consumption
+      formats: ['es', 'cjs'],
+      fileName: (format) => (format === 'es' ? 'index.js' : 'index.cjs'),
     },
     rollupOptions: {
       external: ['react', 'react-dom'],
-      output: {
-        globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM',
-        },
-      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- Refactors component to use consumer-provided CSS modules instead of built-in theme system
- Updates build system to properly export individual CSS files
- Simplifies API by removing theme/mode props in favor of classes prop

## Changes
- **Build System**: Added post-build script to copy CSS files and updated package.json exports
- **Component API**: Replaced `theme` and `mode` props with `classes` prop for CSS modules
- **Theming**: Removed built-in Theme type and internal theme logic
- **Demo**: Updated to demonstrate new CSS modules approach

## Test plan
- [ ] Build completes successfully with CSS files in dist
- [ ] Component renders with consumer-provided CSS modules
- [ ] Demo app works with new theming approach