### PR TITLE
feat: rename site build output to demo

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: site
+          path: demo
 
   deploy:
     environment:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+demo

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -p tsconfig.build.json && vite build && node scripts/copy-css.mjs",
+    "build:demo": "vite build --config vite.site.config.ts",
     "preview": "vite preview",
+    "preview:demo": "vite preview --config vite.site.config.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "biome lint .",
     "format": "biome format .",

--- a/vite.site.config.ts
+++ b/vite.site.config.ts
@@ -5,8 +5,8 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   plugins: [react()],
   build: {
-    // Keep library build output in dist, and site output separate
-    outDir: 'site',
+    // Keep library build output in dist, and demo output separate
+    outDir: 'demo',
   },
 });
 


### PR DESCRIPTION
## Summary
Renames the demo site build output directory from `site` to `demo` for better clarity and consistency.

## Changes
- Updated vite.site.config.ts to output to `demo` directory instead of `site`
- Updated GitHub Pages workflow to deploy from `demo` path
- Added `demo` to .gitignore to exclude build artifacts
- Added `build:demo` and `preview:demo` scripts for better dev experience

## Test plan
- [ ] Verify build:demo creates output in demo directory
- [ ] Verify GitHub Pages deployment works with new path